### PR TITLE
tui: allow manually specify mirror URL

### DIFF
--- a/src/frontend/tui.rs
+++ b/src/frontend/tui.rs
@@ -399,6 +399,7 @@ fn select_mirrors_view(
                         .child(TextView::new(
                             "The path should include protocol and end with \"aosc-os\".",
                         ))
+                        .child(DummyView {})
                         .child(
                             EditView::new()
                                 .on_edit_mut(move |_, c, _| {
@@ -427,7 +428,7 @@ fn select_mirrors_view(
                         name_tr: String::from("user-name"),
                         loc: String::from("User specified"),
                         loc_tr: String::from("user-loc"),
-                        url
+                        url,
                     }));
                     if config_clone.partition.is_some() {
                         select_user_password(s, config_clone);
@@ -437,7 +438,8 @@ fn select_mirrors_view(
                 })
                 .button("Cancel", |s| {
                     s.pop_layer();
-                }),
+                })
+                .padding_lrtb(2, 2, 1, 1),
             );
         })
         .button("Back", move |s| {

--- a/src/network.rs
+++ b/src/network.rs
@@ -135,6 +135,22 @@ pub(crate) fn get_arch_name() -> Option<&'static str> {
     }
 }
 
+/// Issue a HEAD request to the specified url instead of downloading the entire body.
+///
+/// If the server returned a error code the response becomes an error.
+pub fn query_file_meta(url: &String) -> Result<reqwest::blocking::Response> {
+    let client = reqwest::blocking::ClientBuilder::new()
+        .user_agent(DEPLOYKIT_USER_AGENT!())
+        .build()?;
+    let head_response = client.head(url).send();
+
+    let server_response = head_response.map_err(|e| anyhow!("{}", e))?;
+    let server_success = server_response.error_for_status().map_err(|e| anyhow!("{}", e))?;
+
+    Ok(server_success)
+}
+
+
 pub fn download_file(url: String) -> Result<reqwest::blocking::Response> {
     let client = reqwest::blocking::ClientBuilder::new()
         .user_agent(DEPLOYKIT_USER_AGENT!())


### PR DESCRIPTION
This PR adds a "Specify URL" button on mirror selection dialog - basically allowing folks to download from their own mirrors. DK will verify that this URL is reachable with a HEAD request, and proceed to the next step if the mirror server is responding.