### PR TITLE
Fix frontend::cli::test Unsupported architecture issue

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -131,6 +131,7 @@ pub(crate) fn get_arch_name() -> Option<&'static str> {
         "aarch64" => Some("arm64"),
         "mips64" => Some("loongson3"),
         "riscv64" => Some("riscv64"),
+        "loongarch64" => Some("loongarch64"),
         _ => None,
     }
 }


### PR DESCRIPTION
Hi,

before the patch:

```
test frontend::cli::test ... FAILED

failures:

---- frontend::cli::test stdout ----
thread 'frontend::cli::test' panicked at 'called `Result::unwrap()` on an `Err` value: Unsupported architecture.

Stack backtrace:
   0: anyhow::error::<impl anyhow::Error>::msg
             at /home/loongson/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.70/src/error.rs:83:36
   1: anyhow::__private::format_err
             at /home/loongson/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.70/src/lib.rs:668:13
   2: aoscdk_rs::network::find_variant_candidates
             at ./src/network.rs:229:20
   3: aoscdk_rs::network::get_variants
             at ./src/network.rs:97:20
   4: aoscdk_rs::frontend::cli::list_tarball
             at ./src/frontend/cli.rs:143:20
   5: aoscdk_rs::frontend::cli::test
             at ./src/frontend/cli.rs:335:10
   6: aoscdk_rs::frontend::cli::test::{{closure}}
             at ./src/frontend/cli.rs:334:11
   7: core::ops::function::FnOnce::call_once
             at /mnt/repo/loongarch-rs/rust/library/core/src/ops/function.rs:250:5
   8: test::__rust_begin_short_backtrace
   9: core::ops::function::FnOnce::call_once{{vtable.shim}}
  10: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
  11: std::panicking::try::do_call
  12: __rust_try
  13: std::panicking::try
  14: test::run_test_in_process
  15: std::sys_common::backtrace::__rust_begin_short_backtrace
  16: __rust_try
  17: std::panicking::try
  18: core::ops::function::FnOnce::call_once{{vtable.shim}}
  19: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
  20: std::sys::unix::thread::Thread::new::thread_start
  21: <unknown>
  22: <unknown>', src/frontend/cli.rs:335:25
stack backtrace:
   0:     0x555555df5d18 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h36a7aec67b0db3ef
   1:     0x555555e301c8 - core::fmt::write::h7d78873c9f7a736d
   2:     0x555555e02eb4 - std::io::Write::write_fmt::h35a9209192ffff2b
   3:     0x555555df5b58 - std::sys_common::backtrace::print::h4ba366dab4d8d880
   4:     0x555555dfa904 - std::panicking::default_hook::{{closure}}::h0fa66bbe12df1171
   5:     0x555555dfa6ac - std::panicking::default_hook::h997043e2b640b851
   6:     0x555555a0e800 - test::test_main::{{closure}}::ha476fe7ee2eba784
   7:     0x555555dfaed8 - std::panicking::rust_panic_with_hook::h8492e5d1cb5e4152
   8:     0x555555e0dd00 - std::panicking::begin_panic_handler::{{closure}}::hc3d9ead452698424
   9:     0x555555e0dc24 - std::sys_common::backtrace::__rust_end_short_backtrace::h45c79ef3fdbb2db0
  10:     0x555555dfaa5c - rust_begin_unwind
  11:     0x5555559d7f80 - core::panicking::panic_fmt::h5171e01556971d91
  12:     0x5555559d8390 - core::result::unwrap_failed::heb71e99b3bf3a2d1
  13:     0x555555a0ab7c - core::result::Result<T,E>::unwrap::h25f195d06e1ba54f
                               at /mnt/repo/loongarch-rs/rust/library/core/src/result.rs:1076:23
  14:     0x5555559fd780 - aoscdk_rs::frontend::cli::test::h4928e67235b68bd7
                               at /mnt/repo/AOSC-Dev/aoscdk-rs/src/frontend/cli.rs:335:10
  15:     0x5555559dca78 - aoscdk_rs::frontend::cli::test::{{closure}}::h2b227a460162ac79
                               at /mnt/repo/AOSC-Dev/aoscdk-rs/src/frontend/cli.rs:334:11
  16:     0x5555559de08c - core::ops::function::FnOnce::call_once::ha4b599eeb05b284f
                               at /mnt/repo/loongarch-rs/rust/library/core/src/ops/function.rs:250:5
  17:     0x555555a24498 - test::__rust_begin_short_backtrace::hb8fb09d7cef1d86c
  18:     0x555555a0e0dc - core::ops::function::FnOnce::call_once{{vtable.shim}}::h57754659d8bdea20
  19:     0x555555a13c00 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h4bfa228494f44a8d
  20:     0x555555a16874 - std::panicking::try::do_call::h04ec1be3277db09a
  21:     0x555555a169ac - __rust_try
  22:     0x555555a167b8 - std::panicking::try::hef93f790b329fd49
  23:     0x555555a0ffec - test::run_test_in_process::h3f51bd994e74b862
  24:     0x555555a24fe0 - std::sys_common::backtrace::__rust_begin_short_backtrace::h47eee106d55215d3
  25:     0x555555a169ac - __rust_try
  26:     0x555555a166e0 - std::panicking::try::haa1f3a7b633f824b
  27:     0x555555a154bc - core::ops::function::FnOnce::call_once{{vtable.shim}}::h9be3a86e58e59d0b
  28:     0x555555e03e08 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h7b0e374befc11c9e
  29:     0x555555e048bc - std::sys::unix::thread::Thread::new::thread_start::he8eae6a2409e668a
  30:     0x7ffff135d174 - <unknown>
  31:     0x7ffff13c60e4 - <unknown>
  32:                0x0 - <unknown>


failures:
    frontend::cli::test

test result: FAILED. 13 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.12s
```

after the patch fixed the Unsupported architecture issue.

Could you review the patch and give me some suggestion please?

Thanks,
Leslie Zhai